### PR TITLE
feat(api)!: rename color functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,5 @@ pub use utils::image::Image;
 #[cfg(feature = "image")]
 pub use utils::image::ImageReader;
 
-pub use utils::theme::theme_from_source_color;
-
 pub use palettes::core::CorePalette;
 pub use palettes::tonal::TonalPalette;

--- a/src/utils/color.rs
+++ b/src/utils/color.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use std::error::Error;
 use std::str::FromStr;
+#[cfg(feature = "serde")]
+use serde::Serialize;
 
 use super::math::matrix_multiply;
 
@@ -25,6 +27,7 @@ pub const XYZ_TO_SRGB: [[f64; 3]; 3] = [
 pub const WHITE_POINT_D65: [f64; 3] = [95.047, 100.0, 108.883];
 
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Rgb {
     pub red: u8,
     pub green: u8,
@@ -32,6 +35,7 @@ pub struct Rgb {
 }
 
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Argb {
     pub alpha: u8,
     pub red: u8,
@@ -40,6 +44,7 @@ pub struct Argb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct LinearRgb {
     pub red: f64,
     pub green: f64,
@@ -47,6 +52,7 @@ pub struct LinearRgb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Xyz {
     pub x: f64,
     pub y: f64,
@@ -54,6 +60,7 @@ pub struct Xyz {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Lab {
     pub l: f64,
     pub a: f64,

--- a/src/utils/theme.rs
+++ b/src/utils/theme.rs
@@ -37,6 +37,44 @@ pub struct CustomColorGroup {
     pub dark: ColorGroup,
 }
 
+impl CustomColorGroup {
+    /// Generate custom color group from source and target color
+    ///
+
+    ///
+    /// @link https://m3.material.io/styles/color/the-color-system/color-roles
+    fn new(source: Argb, color: CustomColor) -> Self {
+        let mut value = color.value;
+
+        let from = value;
+        let to = source;
+
+        if color.blend {
+            value = harmonize(from, to);
+        }
+
+        let palette = CorePalette::of(value);
+        let tones = palette.primary;
+
+        Self {
+            color,
+            value,
+            light: ColorGroup {
+                color: tones.tone(40),
+                on_color: tones.tone(100),
+                color_container: tones.tone(90),
+                on_color_container: tones.tone(10),
+            },
+            dark: ColorGroup {
+                color: tones.tone(80),
+                on_color: tones.tone(20),
+                color_container: tones.tone(30),
+                on_color_container: tones.tone(90),
+            },
+        }
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Schemes {
@@ -64,77 +102,33 @@ pub struct Theme {
     pub custom_colors: Vec<CustomColorGroup>,
 }
 
-/// Generate a theme from a source color
-///
-/// @param source Source color
-///
-/// @param customColors Array of custom colors
-///
-/// @return Theme object
-pub fn theme_from_source_color(source: Argb, custom_colors: Vec<CustomColor>) -> Theme {
-    let palette = CorePalette::of(source);
+impl Theme {
+    /// Generatse a theme from a source color
+    pub fn from_source_color(source: Argb, custom_colors: Vec<CustomColor>) -> Theme {
+        let palette = CorePalette::of(source);
 
-    Theme {
-        source,
-        schemes: Schemes {
-            light: SchemeTonalSpot::new(source.into(), false, None)
-                .scheme
-                .into(),
-            dark: SchemeTonalSpot::new(source.into(), true, None)
-                .scheme
-                .into(),
-        },
-        palettes: Palettes {
-            primary: palette.primary,
-            secondary: palette.secondary,
-            tertiary: palette.tertiary,
-            neutral: palette.neutral,
-            neutral_variant: palette.neutral_variant,
-            error: palette.error,
-        },
-        custom_colors: custom_colors
-            .into_iter()
-            .map(|c| custom_color(source, c))
-            .collect(),
-    }
-}
-
-/// Generate custom color group from source and target color
-///
-/// @param source Source color
-///
-/// @param color Custom color
-///
-/// @return Custom color group
-///
-/// @link https://m3.material.io/styles/color/the-color-system/color-roles
-fn custom_color(source: Argb, color: CustomColor) -> CustomColorGroup {
-    let mut value = color.value;
-
-    let from = value;
-    let to = source;
-
-    if color.blend {
-        value = harmonize(from, to);
-    }
-
-    let palette = CorePalette::of(value);
-    let tones = palette.primary;
-
-    CustomColorGroup {
-        color,
-        value,
-        light: ColorGroup {
-            color: tones.tone(40),
-            on_color: tones.tone(100),
-            color_container: tones.tone(90),
-            on_color_container: tones.tone(10),
-        },
-        dark: ColorGroup {
-            color: tones.tone(80),
-            on_color: tones.tone(20),
-            color_container: tones.tone(30),
-            on_color_container: tones.tone(90),
-        },
+        Theme {
+            source,
+            schemes: Schemes {
+                light: SchemeTonalSpot::new(source.into(), false, None)
+                    .scheme
+                    .into(),
+                dark: SchemeTonalSpot::new(source.into(), true, None)
+                    .scheme
+                    .into(),
+            },
+            palettes: Palettes {
+                primary: palette.primary,
+                secondary: palette.secondary,
+                tertiary: palette.tertiary,
+                neutral: palette.neutral,
+                neutral_variant: palette.neutral_variant,
+                error: palette.error,
+            },
+            custom_colors: custom_colors
+                .into_iter()
+                .map(|c| CustomColorGroup::new(source, c))
+                .collect(),
+        }
     }
 }

--- a/src/utils/theme.rs
+++ b/src/utils/theme.rs
@@ -55,7 +55,6 @@ pub struct Palettes {
     pub error: TonalPalette,
 }
 
-// Theme
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Theme {

--- a/tests/theme.rs
+++ b/tests/theme.rs
@@ -1,14 +1,14 @@
 use std::str::FromStr;
 
-use material_colors::theme_from_source_color;
 use material_colors::utils::color::ParseRgbError;
+use material_colors::utils::theme::Theme;
 use material_colors::Argb;
 use material_colors::Rgb;
 use material_colors::Scheme;
 
 #[test]
 fn test_theme() -> Result<(), ParseRgbError> {
-    let theme = theme_from_source_color(Argb::from_str("#AAE5A4")?, vec![]);
+    let theme = Theme::from_source_color(Argb::from_str("#AAE5A4")?, vec![]);
 
     assert_eq!(
         theme.schemes.dark,


### PR DESCRIPTION
This renames two functions to be more idiomatic, in line with 0.2 API changes.

- `theme_from_source_color` replaced with `Theme::from_source_color`
- `custom_color` replaced with `CustomColorGroup::new`

Both are breaking.