### PR TITLE
feat: enhance Clippy linting directives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Aiving/material-colors"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["palette", "color-scheme", "material-you"]
+categories = ["graphics"]
 
 [dependencies]
 ahash = "0.8.11"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use material_colors::{Theme, Argb};
 
 fn main() {
-    let theme = Theme::from_source_color(Argb::from_str("#AAE5A4").unwrap(), Default::default());
+    let theme = Theme::from_source_color(Argb::from_str("#AAE5A4").unwrap(), Vec::new());
 
     // Do whatever you want...
 }
@@ -40,7 +40,7 @@ async fn main() -> Result<(), reqwest::Error> {
     // However, if you don't like the results, you can always try other FilterType values.
     data.resize(128, 128, FilterType::Lanczos3);
 
-    let theme = Theme::from_source_color(ImageReader::extract_color(&data), Default::default());
+    let theme = Theme::from_source_color(ImageReader::extract_color(&data), Vec::new());
 
     // Do whatever you want...
 

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -10,10 +10,10 @@ pub fn harmonize(design_color: Argb, source_color: Argb) -> Argb {
     let difference_degrees = difference_degrees(from_hct.get_hue(), to_hct.get_hue());
     let rotation_degrees = (difference_degrees * 0.5).min(15.0);
 
-    let output_hue = sanitize_degrees_double(
-        from_hct.get_hue()
-            + rotation_degrees * rotate_direction(from_hct.get_hue(), to_hct.get_hue()),
-    );
+    let output_hue = sanitize_degrees_double(rotation_degrees.mul_add(
+        rotate_direction(from_hct.get_hue(), to_hct.get_hue()),
+        from_hct.get_hue(),
+    ));
 
     Hct::from(output_hue, from_hct.get_chroma(), from_hct.get_tone()).into()
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -399,7 +399,7 @@ fn lab_f(t: f64) -> f64 {
     let kappa = 24389.0_f64 / 27.0;
 
     if t > e {
-        t.powf(1.0 / 3.0)
+        t.cbrt()
     } else {
         kappa.mul_add(t, 16.0) / 116.0
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -180,7 +180,7 @@ impl From<Argb> for Lab {
         let fy = lab_f(y_normalized);
         let fz = lab_f(z_normalized);
 
-        let l = 116.0 * fy - 16.0;
+        let l = 116.0_f64.mul_add(fy, -16.0);
         let a = 500.0 * (fx - fy);
         let b = 200.0 * (fy - fz);
 
@@ -396,12 +396,12 @@ pub fn delinearized(rgb_component: f64) -> u8 {
 
 fn lab_f(t: f64) -> f64 {
     let e = 216.0 / 24389.0;
-    let kappa = 24389.0 / 27.0;
+    let kappa = 24389.0_f64 / 27.0;
 
     if t > e {
         t.powf(1.0 / 3.0)
     } else {
-        (kappa * t + 16.0) / 116.0
+        kappa.mul_add(t, 16.0) / 116.0
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -188,7 +188,7 @@ impl From<Argb> for Lab {
     }
 }
 
-fn hex_digit_to_rgb(number: u32) -> Rgb {
+const fn hex_digit_to_rgb(number: u32) -> Rgb {
     let r = number >> 16;
     let g = (number >> 8) & 0x00FF;
     let b = number & 0x0000_00FF;

--- a/src/color.rs
+++ b/src/color.rs
@@ -368,7 +368,7 @@ pub fn lstar_from_y(y: f64) -> f64 {
  * @return 0.0 <= output <= 100.0, color channel converted to linear Rgb space
  */
 pub fn linearized(rgb_component: u8) -> f64 {
-    let normalized = rgb_component as f64 / 255.0;
+    let normalized = f64::from(rgb_component) / 255.0;
 
     if normalized <= 0.040449936 {
         normalized / 12.92 * 100.0

--- a/src/color.rs
+++ b/src/color.rs
@@ -67,8 +67,8 @@ pub struct Lab {
 
 /** Converts a color from Rgb components to Argb format. */
 impl From<Rgb> for Argb {
-    fn from(Rgb { red, green, blue }: Rgb) -> Argb {
-        Argb {
+    fn from(Rgb { red, green, blue }: Rgb) -> Self {
+        Self {
             alpha: 255,
             red,
             green,
@@ -79,7 +79,7 @@ impl From<Rgb> for Argb {
 
 /** Converts a color from linear Rgb components to Argb format. */
 impl From<LinearRgb> for Argb {
-    fn from(linear: LinearRgb) -> Argb {
+    fn from(linear: LinearRgb) -> Self {
         let r = delinearized(linear.red);
         let g = delinearized(linear.green);
         let b = delinearized(linear.blue);
@@ -90,7 +90,7 @@ impl From<LinearRgb> for Argb {
 
 /** Converts a color from Argb to Xyz. */
 impl From<Xyz> for Argb {
-    fn from(Xyz { x, y, z }: Xyz) -> Argb {
+    fn from(Xyz { x, y, z }: Xyz) -> Self {
         let matrix = XYZ_TO_SRGB;
 
         let linear_r = matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z;
@@ -114,20 +114,20 @@ impl From<Argb> for Xyz {
             green,
             blue,
         }: Argb,
-    ) -> Xyz {
+    ) -> Self {
         let r = linearized(red);
         let g = linearized(green);
         let b = linearized(blue);
 
         let [x, y, z] = matrix_multiply([r, g, b], SRGB_TO_XYZ);
 
-        Xyz { x, y, z }
+        Self { x, y, z }
     }
 }
 
 /** Converts a color represented in Lab color space into an Argb integer. */
 impl From<Lab> for Argb {
-    fn from(Lab { l, a, b }: Lab) -> Argb {
+    fn from(Lab { l, a, b }: Lab) -> Self {
         let white_point = WHITE_POINT_D65;
 
         let fy = (l + 16.0) / 116.0;
@@ -159,7 +159,7 @@ impl From<Argb> for Lab {
             green,
             blue,
         }: Argb,
-    ) -> Lab {
+    ) -> Self {
         let linear_r = linearized(red);
         let linear_g = linearized(green);
         let linear_b = linearized(blue);
@@ -184,7 +184,7 @@ impl From<Argb> for Lab {
         let a = 500.0 * (fx - fy);
         let b = 200.0 * (fy - fz);
 
-        Lab { l, a, b }
+        Self { l, a, b }
     }
 }
 
@@ -318,9 +318,9 @@ impl Argb {
     pub fn as_hex(&self) -> String {
         format!(
             "#{}{}{}",
-            Argb::hex(self.red),
-            Argb::hex(self.green),
-            Argb::hex(self.blue)
+            Self::hex(self.red),
+            Self::hex(self.green),
+            Self::hex(self.blue)
         )
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -306,7 +306,7 @@ impl Argb {
     }
 
     fn hex(number: u8) -> String {
-        let string = format!("{:x}", number);
+        let string = format!("{number:x}");
 
         if string.len() == 1 {
             String::from("0") + &string

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -14,7 +14,11 @@ pub fn ratio_of_tones(tone_a: f64, tone_b: f64) -> f64 {
 
 fn ratio_of_ys(y1: f64, y2: f64) -> f64 {
     let lighter = if y1 > y2 { y1 } else { y2 };
-    let darker = if lighter == y2 { y1 } else { y2 };
+    let darker = if (lighter - y2).abs() < f64::EPSILON {
+        y1
+    } else {
+        y2
+    };
 
     (lighter + 5.0) / (darker + 5.0)
 }

--- a/src/contrast.rs
+++ b/src/contrast.rs
@@ -34,7 +34,7 @@ pub fn lighter(tone: f64, ratio: f64) -> f64 {
     }
 
     let dark_y = y_from_lstar(tone);
-    let light_y = ratio * (dark_y + 5.0) - 5.0;
+    let light_y = ratio.mul_add(dark_y + 5.0, -5.0);
     let real_contrast = ratio_of_ys(light_y, dark_y);
     let delta = (real_contrast - ratio).abs();
 

--- a/src/dynamic_color/dynamic_scheme.rs
+++ b/src/dynamic_color/dynamic_scheme.rs
@@ -72,7 +72,7 @@ impl DynamicScheme {
     ) -> Self {
         Self {
             source_color_argb,
-            source_color_hct: source_color_hct.unwrap_or(source_color_argb.into()),
+            source_color_hct: source_color_hct.unwrap_or_else(|| source_color_argb.into()),
             variant,
             is_dark,
             contrast_level: contrast_level.unwrap_or(0.0),
@@ -81,7 +81,7 @@ impl DynamicScheme {
             tertiary_palette,
             neutral_palette,
             neutral_variant_palette,
-            error_palette: error_palette.unwrap_or(TonalPalette::of(25.0, 84.0)),
+            error_palette: error_palette.unwrap_or_else(|| TonalPalette::of(25.0, 84.0)),
         }
     }
 

--- a/src/dynamic_color/dynamic_scheme.rs
+++ b/src/dynamic_color/dynamic_scheme.rs
@@ -85,7 +85,7 @@ impl DynamicScheme {
         }
     }
 
-    pub fn get_rotated_hue(source_color: Hct, hues: Vec<f64>, rotations: Vec<f64>) -> f64 {
+    pub fn get_rotated_hue(source_color: Hct, hues: &[f64], rotations: &[f64]) -> f64 {
         let source_hue = source_color.get_hue();
 
         assert!(hues.len() == rotations.len());

--- a/src/dynamic_color/material_dynamic_colors.rs
+++ b/src/dynamic_color/material_dynamic_colors.rs
@@ -2,11 +2,11 @@ use crate::{dislike::fix_if_disliked, Hct};
 
 use super::{ContrastCurve, DynamicColor, DynamicScheme, ToneDeltaPair, TonePolarity, Variant};
 
-fn _is_fidelity(scheme: &DynamicScheme) -> bool {
+const fn _is_fidelity(scheme: &DynamicScheme) -> bool {
     matches!(scheme.variant, Variant::Fidelity) || matches!(scheme.variant, Variant::Content)
 }
 
-fn _is_monochrome(scheme: &DynamicScheme) -> bool {
+const fn _is_monochrome(scheme: &DynamicScheme) -> bool {
     matches!(scheme.variant, Variant::Monochrome)
 }
 

--- a/src/dynamic_color/material_dynamic_colors.rs
+++ b/src/dynamic_color/material_dynamic_colors.rs
@@ -164,7 +164,7 @@ impl MaterialDynamicColors {
     define_key! {
       on_background => neutral_palette;
       [tone, scheme] => if scheme.is_dark { 90.0 } else { 10.0 };
-      [background, _scheme] => MaterialDynamicColors::background();
+      [background, _scheme] => Self::background();
       [contrast_curve] => ContrastCurve { low: 3.0, normal: 3.0, medium: 4.5, high: 7.0 };
     }
 
@@ -330,7 +330,7 @@ impl MaterialDynamicColors {
 
     define_key! {
       on_secondary_container => secondary_palette;
-      [tone, scheme] => if _is_fidelity(scheme) { DynamicColor::foreground_tone(MaterialDynamicColors::secondary_container().get_tone(scheme), 4.5) } else if scheme.is_dark { 90.0 } else { 10.0 };
+      [tone, scheme] => if _is_fidelity(scheme) { DynamicColor::foreground_tone(Self::secondary_container().get_tone(scheme), 4.5) } else if scheme.is_dark { 90.0 } else { 10.0 };
       [background, scheme] => Self::highest_surface(scheme);
       [contrast_curve] => ContrastCurve { low: 4.5, normal: 7.0, medium: 11.0, high: 21.0 };
     }

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -147,6 +147,7 @@ impl DynamicColor {
     ///   contrast level is.
     /// - Returns: a tone, T in the HCT color space, that this `DynamicColor` is under
     ///   the conditions in `scheme`.
+    #[allow(clippy::useless_let_if_seq)]
     pub fn get_tone(&self, scheme: &DynamicScheme) -> f64 {
         let decreasing_contrast = scheme.contrast_level < 0.0;
 

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -108,7 +108,7 @@ impl DynamicColor {
             second_background: second_background.map(Box::new),
             contrast_curve,
             tone_delta_pair: tone_delta_pair.map(Box::new),
-            _hct_cache: Default::default(),
+            _hct_cache: HashMap::default(),
         }
     }
 

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -209,13 +209,13 @@ impl DynamicColor {
                 // Good! Tones satisfy the constraint; no change needed.
             } else {
                 // 2nd round: expand farther to match delta.
-                f_tone = (n_tone + delta * expansion_dir).clamp(0.0, 100.0);
+                f_tone = delta.mul_add(expansion_dir, n_tone).clamp(0.0, 100.0);
 
                 if (f_tone - n_tone) * expansion_dir >= delta {
                     // Good! Tones now satisfy the constraint; no change needed.
                 } else {
                     // 3rd round: contract nearer to match delta.
-                    n_tone = (f_tone - delta * expansion_dir).clamp(0.0, 100.0);
+                    n_tone = delta.mul_add(-expansion_dir, f_tone).clamp(0.0, 100.0);
                 }
             }
 
@@ -225,10 +225,10 @@ impl DynamicColor {
                 // `farther`.
                 if expansion_dir > 0.0 {
                     n_tone = 60.0;
-                    f_tone = f_tone.max(n_tone + delta * expansion_dir);
+                    f_tone = f_tone.max(delta.mul_add(expansion_dir, n_tone));
                 } else {
                     n_tone = 49.0;
-                    f_tone = f_tone.min(n_tone + delta * expansion_dir);
+                    f_tone = f_tone.min(delta.mul_add(expansion_dir, n_tone));
                 }
             } else if (50.0..60.0).contains(&f_tone) {
                 if stay_together {
@@ -236,10 +236,10 @@ impl DynamicColor {
                     // zone".
                     if expansion_dir > 0.0 {
                         n_tone = 60.0;
-                        f_tone = f_tone.max(n_tone + delta * expansion_dir);
+                        f_tone = f_tone.max(delta.mul_add(expansion_dir, n_tone));
                     } else {
                         n_tone = 49.0;
-                        f_tone = f_tone.min(n_tone + delta * expansion_dir);
+                        f_tone = f_tone.min(delta.mul_add(expansion_dir, n_tone));
                     }
                 } else {
                     // Not required to stay together; fixes just one.

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -94,8 +94,8 @@ impl DynamicColor {
         palette: fn(&DynamicScheme) -> &TonalPalette,
         tone: fn(&DynamicScheme) -> f64,
         is_background: bool,
-        background: Option<fn(&DynamicScheme) -> DynamicColor>,
-        second_background: Option<fn(&DynamicScheme) -> DynamicColor>,
+        background: Option<fn(&DynamicScheme) -> Self>,
+        second_background: Option<fn(&DynamicScheme) -> Self>,
         contrast_curve: Option<ContrastCurve>,
         tone_delta_pair: Option<fn(&DynamicScheme) -> ToneDeltaPair>,
     ) -> Self {
@@ -188,21 +188,21 @@ impl DynamicColor {
             let mut n_tone = if ratio_of_tones(bg_tone, n_initial_tone) >= n_contrast {
                 n_initial_tone
             } else {
-                DynamicColor::foreground_tone(bg_tone, n_contrast)
+                Self::foreground_tone(bg_tone, n_contrast)
             };
             // Initial and adjusted tones for `farther`
             let f_initial_tone = (farther.tone)(scheme);
             let mut f_tone = if ratio_of_tones(bg_tone, f_initial_tone) >= f_contrast {
                 f_initial_tone
             } else {
-                DynamicColor::foreground_tone(bg_tone, f_contrast)
+                Self::foreground_tone(bg_tone, f_contrast)
             };
 
             if decreasing_contrast {
                 // If decreasing contrast, adjust color to the "bare minimum"
                 // that satisfies contrast.
-                n_tone = DynamicColor::foreground_tone(bg_tone, n_contrast);
-                f_tone = DynamicColor::foreground_tone(bg_tone, f_contrast);
+                n_tone = Self::foreground_tone(bg_tone, n_contrast);
+                f_tone = Self::foreground_tone(bg_tone, f_contrast);
             }
 
             if (f_tone - n_tone) * expansion_dir >= delta {
@@ -274,11 +274,11 @@ impl DynamicColor {
                     // Don't "improve" what's good enough.
                 } else {
                     // Rough improvement.
-                    answer = DynamicColor::foreground_tone(bg_tone, desired_ratio);
+                    answer = Self::foreground_tone(bg_tone, desired_ratio);
                 }
 
                 if decreasing_contrast {
-                    answer = DynamicColor::foreground_tone(bg_tone, desired_ratio);
+                    answer = Self::foreground_tone(bg_tone, desired_ratio);
                 }
 
                 if self.is_background && (50.0..60.0).contains(&answer) {
@@ -323,8 +323,8 @@ impl DynamicColor {
                         availables.push(dark_option);
                     }
 
-                    let prefers_light = DynamicColor::tone_prefers_light_foreground(bg_tone1)
-                        || DynamicColor::tone_prefers_light_foreground(bg_tone2);
+                    let prefers_light = Self::tone_prefers_light_foreground(bg_tone1)
+                        || Self::tone_prefers_light_foreground(bg_tone2);
 
                     if prefers_light {
                         return if light_option < 0.0 {

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -317,10 +317,10 @@ impl DynamicColor {
                     let mut availables: Vec<f64> = vec![];
 
                     if light_option != -1.0 {
-                        availables.push(light_option)
+                        availables.push(light_option);
                     }
                     if dark_option != -1.0 {
-                        availables.push(dark_option)
+                        availables.push(dark_option);
                     }
 
                     let prefers_light = DynamicColor::tone_prefers_light_foreground(bg_tone1)

--- a/src/dynamic_color/mod.rs
+++ b/src/dynamic_color/mod.rs
@@ -316,10 +316,10 @@ impl DynamicColor {
                     // Tones suitable for the foreground.
                     let mut availables: Vec<f64> = vec![];
 
-                    if light_option != -1.0 {
+                    if (light_option - -1.0).abs() > f64::EPSILON {
                         availables.push(light_option);
                     }
-                    if dark_option != -1.0 {
+                    if (dark_option - -1.0).abs() > f64::EPSILON {
                         availables.push(dark_option);
                     }
 

--- a/src/dynamic_color/tone_delta_pair.rs
+++ b/src/dynamic_color/tone_delta_pair.rs
@@ -48,7 +48,7 @@ impl ToneDeltaPair {
     /// * `stayTogether`: Whether these two roles should stay on the same side of
     ///   the "awkward zone" (T50-59). This is necessary for certain cases where
     ///   one role has two backgrounds.
-    pub fn new(
+    pub const fn new(
         subject: DynamicColor,
         basis: DynamicColor,
         delta: f64,

--- a/src/hct/cam16.rs
+++ b/src/hct/cam16.rs
@@ -68,7 +68,7 @@ impl Cam16 {
     /// CAM16 instances also have coordinates in the CAM16-UCS space, called J*,
     /// a*, b*, or jstar, astar, bstar in code. CAM16-UCS is included in the CAM16
     /// specification, and should be used when measuring distances between colors.
-    pub fn distance(&self, other: Cam16) -> f64 {
+    pub fn distance(&self, other: &Cam16) -> f64 {
         let d_j = self.jstar - other.jstar;
         let d_a = self.astar - other.astar;
         let d_b = self.bstar - other.bstar;
@@ -80,7 +80,7 @@ impl Cam16 {
     /// Given [viewing_conditions], convert [argb] to
     pub fn fromi32_in_viewing_conditions(
         argb: Argb,
-        viewing_conditions: ViewingConditions,
+        viewing_conditions: &ViewingConditions,
     ) -> Cam16 {
         // Transform Argb int to Xyz
         let Xyz { x, y, z } = Xyz::from(argb);
@@ -94,7 +94,7 @@ impl Cam16 {
         x: f64,
         y: f64,
         z: f64,
-        viewing_conditions: ViewingConditions,
+        viewing_conditions: &ViewingConditions,
     ) -> Cam16 {
         // Transform Xyz to 'cone'/'rgb' responses
         let r_c = 0.401288 * x + 0.650173 * y - 0.051461 * z;
@@ -181,7 +181,7 @@ impl Cam16 {
     /// Create a CAM16 color from lightness [j], chroma [c], and hue [h],
     /// assuming the color was viewed in default viewing conditions.
     pub fn from_jch(j: f64, c: f64, h: f64) -> Self {
-        Cam16::from_jch_in_viewing_conditions(j, c, h, ViewingConditions::s_rgb())
+        Cam16::from_jch_in_viewing_conditions(j, c, h, &ViewingConditions::s_rgb())
     }
 
     /// Create a CAM16 color from lightness [j], chroma [c], and hue [h],
@@ -190,7 +190,7 @@ impl Cam16 {
         j: f64,
         c: f64,
         h: f64,
-        viewing_conditions: ViewingConditions,
+        viewing_conditions: &ViewingConditions,
     ) -> Cam16 {
         let q = (4.0 / viewing_conditions.c)
             * (j / 100.0).sqrt()
@@ -222,7 +222,7 @@ impl Cam16 {
     /// Create a CAM16 color from CAM16-UCS coordinates [jstar], [astar], [bstar].
     /// assuming the color was viewed in default viewing conditions.
     pub fn from_ucs(jstar: f64, astar: f64, bstar: f64) -> Cam16 {
-        Cam16::from_ucs_in_viewing_conditions(jstar, astar, bstar, ViewingConditions::standard())
+        Cam16::from_ucs_in_viewing_conditions(jstar, astar, bstar, &ViewingConditions::standard())
     }
 
     /// Create a CAM16 color from CAM16-UCS coordinates [jstar], [astar], [bstar].
@@ -231,7 +231,7 @@ impl Cam16 {
         jstar: f64,
         astar: f64,
         bstar: f64,
-        viewing_conditions: ViewingConditions,
+        viewing_conditions: &ViewingConditions,
     ) -> Cam16 {
         let a = astar;
         let b = bstar;
@@ -250,14 +250,14 @@ impl Cam16 {
 
     /// Argb representation of a color, given the color was viewed in
     /// [viewing_conditions]
-    pub fn viewed(&self, viewing_conditions: ViewingConditions) -> Argb {
+    pub fn viewed(&self, viewing_conditions: &ViewingConditions) -> Argb {
         let xyz = self.xyz_in_viewing_conditions(viewing_conditions);
 
         xyz.into()
     }
 
     /// Xyz representation of CAM16 seen in [viewing_conditions].
-    pub fn xyz_in_viewing_conditions(&self, viewing_conditions: ViewingConditions) -> Xyz {
+    pub fn xyz_in_viewing_conditions(&self, viewing_conditions: &ViewingConditions) -> Xyz {
         let alpha = if self.chroma == 0.0 || self.j == 0.0 {
             0.0
         } else {
@@ -305,12 +305,12 @@ impl Cam16 {
 
 impl From<Argb> for Cam16 {
     fn from(argb: Argb) -> Self {
-        Cam16::fromi32_in_viewing_conditions(argb, ViewingConditions::s_rgb())
+        Cam16::fromi32_in_viewing_conditions(argb, &ViewingConditions::s_rgb())
     }
 }
 
 impl From<Cam16> for Argb {
     fn from(val: Cam16) -> Self {
-        val.viewed(ViewingConditions::s_rgb())
+        val.viewed(&ViewingConditions::s_rgb())
     }
 }

--- a/src/hct/cam16.rs
+++ b/src/hct/cam16.rs
@@ -68,7 +68,7 @@ impl Cam16 {
     /// CAM16 instances also have coordinates in the CAM16-UCS space, called J*,
     /// a*, b*, or jstar, astar, bstar in code. CAM16-UCS is included in the CAM16
     /// specification, and should be used when measuring distances between colors.
-    pub fn distance(&self, other: &Cam16) -> f64 {
+    pub fn distance(&self, other: &Self) -> f64 {
         let d_j = self.jstar - other.jstar;
         let d_a = self.astar - other.astar;
         let d_b = self.bstar - other.bstar;
@@ -81,11 +81,11 @@ impl Cam16 {
     pub fn fromi32_in_viewing_conditions(
         argb: Argb,
         viewing_conditions: &ViewingConditions,
-    ) -> Cam16 {
+    ) -> Self {
         // Transform Argb int to Xyz
         let Xyz { x, y, z } = Xyz::from(argb);
 
-        Cam16::from_xyz_in_viewing_conditions(x, y, z, viewing_conditions)
+        Self::from_xyz_in_viewing_conditions(x, y, z, viewing_conditions)
     }
 
     /// Given color expressed in Xyz and viewed in [viewing_conditions], convert to
@@ -95,7 +95,7 @@ impl Cam16 {
         y: f64,
         z: f64,
         viewing_conditions: &ViewingConditions,
-    ) -> Cam16 {
+    ) -> Self {
         // Transform Xyz to 'cone'/'rgb' responses
         let r_c = 0.401288 * x + 0.650173 * y - 0.051461 * z;
         let g_c = -0.250268 * x + 1.204414 * y + 0.045854 * z;
@@ -181,7 +181,7 @@ impl Cam16 {
     /// Create a CAM16 color from lightness [j], chroma [c], and hue [h],
     /// assuming the color was viewed in default viewing conditions.
     pub fn from_jch(j: f64, c: f64, h: f64) -> Self {
-        Cam16::from_jch_in_viewing_conditions(j, c, h, &ViewingConditions::s_rgb())
+        Self::from_jch_in_viewing_conditions(j, c, h, &ViewingConditions::s_rgb())
     }
 
     /// Create a CAM16 color from lightness [j], chroma [c], and hue [h],
@@ -191,7 +191,7 @@ impl Cam16 {
         c: f64,
         h: f64,
         viewing_conditions: &ViewingConditions,
-    ) -> Cam16 {
+    ) -> Self {
         let q = (4.0 / viewing_conditions.c)
             * (j / 100.0).sqrt()
             * (viewing_conditions.aw + 4.0)
@@ -206,7 +206,7 @@ impl Cam16 {
         let astar = mstar * hue_radians.cos();
         let bstar = mstar * hue_radians.sin();
 
-        Cam16 {
+        Self {
             hue: h,
             chroma: c,
             j,
@@ -221,8 +221,8 @@ impl Cam16 {
 
     /// Create a CAM16 color from CAM16-UCS coordinates [jstar], [astar], [bstar].
     /// assuming the color was viewed in default viewing conditions.
-    pub fn from_ucs(jstar: f64, astar: f64, bstar: f64) -> Cam16 {
-        Cam16::from_ucs_in_viewing_conditions(jstar, astar, bstar, &ViewingConditions::standard())
+    pub fn from_ucs(jstar: f64, astar: f64, bstar: f64) -> Self {
+        Self::from_ucs_in_viewing_conditions(jstar, astar, bstar, &ViewingConditions::standard())
     }
 
     /// Create a CAM16 color from CAM16-UCS coordinates [jstar], [astar], [bstar].
@@ -232,7 +232,7 @@ impl Cam16 {
         astar: f64,
         bstar: f64,
         viewing_conditions: &ViewingConditions,
-    ) -> Cam16 {
+    ) -> Self {
         let a = astar;
         let b = bstar;
         let m = (a * a + b * b).sqrt();
@@ -242,7 +242,7 @@ impl Cam16 {
         let h = if h < 0.0 { h + 360.0 } else { h };
         let j = jstar / (jstar - 100.0).mul_add(-0.007, 1.0);
 
-        Cam16::from_jch_in_viewing_conditions(j, c, h, viewing_conditions)
+        Self::from_jch_in_viewing_conditions(j, c, h, viewing_conditions)
     }
 
     // Avoid allocations during conversion by pre-allocating an array.
@@ -305,7 +305,7 @@ impl Cam16 {
 
 impl From<Argb> for Cam16 {
     fn from(argb: Argb) -> Self {
-        Cam16::fromi32_in_viewing_conditions(argb, &ViewingConditions::s_rgb())
+        Self::fromi32_in_viewing_conditions(argb, &ViewingConditions::s_rgb())
     }
 }
 

--- a/src/hct/cam16.rs
+++ b/src/hct/cam16.rs
@@ -150,7 +150,7 @@ impl Cam16 {
         let hue_prime = if hue < 20.14 { hue + 360.0 } else { hue };
         let e_hue = (1.0 / 4.0) * ((hue_prime.to_radians() + 2.0).cos() + 3.8);
         let p1 = 50000.0 / 13.0 * e_hue * viewing_conditions.n_c * viewing_conditions.ncb;
-        let t = p1 * (a * a + b * b).sqrt() / (u + 0.305);
+        let t = p1 * a.hypot(b) / (u + 0.305);
         let alpha = t.powf(0.9)
             * (1.64 - 0.29_f64.powf(viewing_conditions.background_ytowhite_point_y)).powf(0.73);
 
@@ -235,8 +235,8 @@ impl Cam16 {
     ) -> Self {
         let a = astar;
         let b = bstar;
-        let m = (a * a + b * b).sqrt();
-        let m = ((m * 0.0228).exp() - 1.0) / 0.0228;
+        let m = a.hypot(b);
+        let m = (m * 0.0228).exp_m1() / 0.0228;
         let c = m / viewing_conditions.f_lroot;
         let h = b.atan2(a) * (180.0 / PI);
         let h = if h < 0.0 { h + 360.0 } else { h };

--- a/src/hct/mod.rs
+++ b/src/hct/mod.rs
@@ -32,7 +32,7 @@ impl Hct {
     /// limited sRgb gamut for display. This will change its Argb/integer
     /// representation. If the HCT color is outside of the sRgb gamut, chroma
     /// will decrease until it is inside the gamut.
-    pub fn get_hue(&self) -> f64 {
+    pub const fn get_hue(&self) -> f64 {
         self._hue
     }
 
@@ -59,7 +59,7 @@ impl Hct {
     /// limited sRgb gamut for display. This will change its Argb/integer
     /// representation. If the HCT color is outside of the sRgb gamut, chroma
     /// will decrease until it is inside the gamut.
-    pub fn get_chroma(&self) -> f64 {
+    pub const fn get_chroma(&self) -> f64 {
         self._chroma
     }
 
@@ -85,7 +85,7 @@ impl Hct {
     /// limited sRgb gamut for display. This will change its Argb/integer
     /// representation. If the HCT color is outside of the sRgb gamut, chroma
     /// will decrease until it is inside the gamut.
-    pub fn get_tone(&self) -> f64 {
+    pub const fn get_tone(&self) -> f64 {
         self._tone
     }
 

--- a/src/hct/mod.rs
+++ b/src/hct/mod.rs
@@ -146,7 +146,7 @@ impl Hct {
     /// CAM16, a color appearance model, and uses it to make these calculations.
     ///
     /// See [ViewingConditions.make] for parameters affecting color appearance.
-    pub fn in_viewing_conditions(self, vc: ViewingConditions) -> Hct {
+    pub fn in_viewing_conditions(self, vc: &ViewingConditions) -> Hct {
         // 1. Use CAM16 to find Xyz coordinates of color in specified VC.
         let cam16 = Cam16::from(Argb::from(self));
         let viewed_in_vc = cam16.xyz_in_viewing_conditions(vc);
@@ -156,7 +156,7 @@ impl Hct {
             viewed_in_vc.x,
             viewed_in_vc.y,
             viewed_in_vc.z,
-            ViewingConditions::standard(),
+            &ViewingConditions::standard(),
         );
 
         // 3. Create HCT from:

--- a/src/hct/mod.rs
+++ b/src/hct/mod.rs
@@ -128,10 +128,10 @@ impl Hct {
     ///    lower than the requested chroma. Chroma has a different maximum for any
     ///    given hue and tone.
     /// 0 <= [tone] <= 100; informally, lightness. Invalid values are corrected.
-    pub fn from(hue: f64, chroma: f64, tone: f64) -> Hct {
+    pub fn from(hue: f64, chroma: f64, tone: f64) -> Self {
         let argb = HctSolver::solve_to_int(hue, chroma, tone);
 
-        Hct::new(argb)
+        Self::new(argb)
     }
 
     /// Translate a color into different [ViewingConditions].
@@ -147,7 +147,7 @@ impl Hct {
     ///
     /// See [ViewingConditions.make] for parameters affecting color appearance.
     #[must_use]
-    pub fn in_viewing_conditions(self, vc: &ViewingConditions) -> Hct {
+    pub fn in_viewing_conditions(self, vc: &ViewingConditions) -> Self {
         // 1. Use CAM16 to find Xyz coordinates of color in specified VC.
         let cam16 = Cam16::from(Argb::from(self));
         let viewed_in_vc = cam16.xyz_in_viewing_conditions(vc);
@@ -163,7 +163,7 @@ impl Hct {
         // 3. Create HCT from:
         // - CAM16 using default VC with Xyz coordinates in specified VC.
         // - L* converted from Y in Xyz coordinates in specified VC.
-        Hct::from(
+        Self::from(
             recast_in_vc.hue,
             recast_in_vc.chroma,
             lstar_from_y(viewed_in_vc.y),
@@ -199,7 +199,7 @@ impl Hash for Hct {
 
 impl From<Argb> for Hct {
     fn from(value: Argb) -> Self {
-        Hct::new(value)
+        Self::new(value)
     }
 }
 

--- a/src/hct/mod.rs
+++ b/src/hct/mod.rs
@@ -146,6 +146,7 @@ impl Hct {
     /// CAM16, a color appearance model, and uses it to make these calculations.
     ///
     /// See [ViewingConditions.make] for parameters affecting color appearance.
+    #[must_use]
     pub fn in_viewing_conditions(self, vc: &ViewingConditions) -> Hct {
         // 1. Use CAM16 to find Xyz coordinates of color in specified VC.
         let cam16 = Cam16::from(Argb::from(self));

--- a/src/hct/solver.rs
+++ b/src/hct/solver.rs
@@ -531,21 +531,19 @@ impl HctSolver {
                 for _ in 0..8 {
                     if (i16::from(r_plane) - i16::from(l_plane)).abs() <= 1 {
                         break;
-                    } else {
-                        let m_plane =
-                            ((f32::from(l_plane) + f32::from(r_plane)) / 2.0).floor() as u8;
-                        let mid_plane_coordinate = CRITICAL_PLANES[m_plane as usize];
-                        let mid = Self::set_coordinate(left, mid_plane_coordinate, right, axis);
-                        let mid_hue = Self::hue_of(mid);
+                    }
+                    let m_plane = ((f32::from(l_plane) + f32::from(r_plane)) / 2.0).floor() as u8;
+                    let mid_plane_coordinate = CRITICAL_PLANES[m_plane as usize];
+                    let mid = Self::set_coordinate(left, mid_plane_coordinate, right, axis);
+                    let mid_hue = Self::hue_of(mid);
 
-                        if Self::are_in_cyclic_order(left_hue, target_hue, mid_hue) {
-                            right = mid;
-                            r_plane = m_plane;
-                        } else {
-                            left = mid;
-                            left_hue = mid_hue;
-                            l_plane = m_plane;
-                        }
+                    if Self::are_in_cyclic_order(left_hue, target_hue, mid_hue) {
+                        right = mid;
+                        r_plane = m_plane;
+                    } else {
+                        left = mid;
+                        left_hue = mid_hue;
+                        l_plane = m_plane;
                     }
                 }
             }

--- a/src/hct/solver.rs
+++ b/src/hct/solver.rs
@@ -529,10 +529,10 @@ impl HctSolver {
                 };
 
                 for _ in 0..8 {
-                    if (r_plane as i16 - l_plane as i16).abs() <= 1 {
+                    if (i16::from(r_plane) - i16::from(l_plane)).abs() <= 1 {
                         break;
                     } else {
-                        let m_plane = ((l_plane as f32 + r_plane as f32) / 2.0).floor() as u8;
+                        let m_plane = ((f32::from(l_plane) + f32::from(r_plane)) / 2.0).floor() as u8;
                         let mid_plane_coordinate = CRITICAL_PLANES[m_plane as usize];
                         let mid = Self::set_coordinate(left, mid_plane_coordinate, right, axis);
                         let mid_hue = Self::hue_of(mid);

--- a/src/hct/solver.rs
+++ b/src/hct/solver.rs
@@ -515,7 +515,7 @@ impl HctSolver {
         let mut right = segment[1];
 
         for axis in 0..3 {
-            if left[axis] != right[axis] {
+            if (left[axis] - right[axis]).abs() > f64::EPSILON {
                 let [mut l_plane, mut r_plane] = if left[axis] < right[axis] {
                     [
                         Self::critical_plane_below(Self::true_delinearized(left[axis])),
@@ -532,7 +532,8 @@ impl HctSolver {
                     if (i16::from(r_plane) - i16::from(l_plane)).abs() <= 1 {
                         break;
                     } else {
-                        let m_plane = ((f32::from(l_plane) + f32::from(r_plane)) / 2.0).floor() as u8;
+                        let m_plane =
+                            ((f32::from(l_plane) + f32::from(r_plane)) / 2.0).floor() as u8;
                         let mid_plane_coordinate = CRITICAL_PLANES[m_plane as usize];
                         let mid = Self::set_coordinate(left, mid_plane_coordinate, right, axis);
                         let mid_hue = Self::hue_of(mid);

--- a/src/hct/solver.rs
+++ b/src/hct/solver.rs
@@ -301,7 +301,7 @@ impl HctSolver {
     /// [angle] An angle in radians; must not deviate too much from 0.
     /// Returns A coterminal angle between 0 and 2pi.
     fn sanitize_radians(angle: f64) -> f64 {
-        (angle + PI * 8.0) % (PI * 2.0)
+        PI.mul_add(8.0, angle) % (PI * 2.0)
     }
 
     /// Delinearizes an Rgb component, returning a floating-point
@@ -408,9 +408,9 @@ impl HctSolver {
         let coord_b = if n % 2 == 0 { 0.0 } else { 100.0 };
 
         if n < 4 {
-            let g = coord_a;
+            let g: f64 = coord_a;
             let b = coord_b;
-            let r = (y - g * k_g - b * k_b) / k_r;
+            let r = (g.mul_add(-k_g, y) - b * k_b) / k_r;
 
             if Self::is_bounded(r) {
                 [r, g, b]
@@ -430,7 +430,7 @@ impl HctSolver {
         } else {
             let r = coord_a;
             let g = coord_b;
-            let b = (y - r * k_r - g * k_g) / k_b;
+            let b = (r.mul_add(-k_r, y) - g * k_g) / k_b;
 
             if Self::is_bounded(b) {
                 [r, g, b]

--- a/src/hct/viewing_conditions.rs
+++ b/src/hct/viewing_conditions.rs
@@ -124,7 +124,7 @@ impl ViewingConditions {
         ];
 
         // Factor used in calculating meaningful factors
-        let k = 1.0 / (5.0 * adapting_luminance + 1.0);
+        let k = 1.0 / 5.0_f64.mul_add(adapting_luminance, 1.0);
         let k4 = k * k * k * k; // pow(k, 4)
         let k4_f = 1.0 - k4;
 

--- a/src/hct/viewing_conditions.rs
+++ b/src/hct/viewing_conditions.rs
@@ -97,13 +97,7 @@ impl ViewingConditions {
             f * (1.0 - ((1.0 / 3.6) * ((-adapting_luminance - 42.0) / 92.0).exp()))
         };
         // Per Li et al, if D is greater than 1 or less than 0, set it to 1 or 0.
-        let d = if d > 1.0 {
-            1.0
-        } else if d < 0.0 {
-            0.0
-        } else {
-            d
-        };
+        let d = d.clamp(0.0, 1.0);
         // chromatic induction factor
         let nc = f;
 

--- a/src/hct/viewing_conditions.rs
+++ b/src/hct/viewing_conditions.rs
@@ -129,8 +129,8 @@ impl ViewingConditions {
         let k4_f = 1.0 - k4;
 
         // Luminance-level adaptation factor
-        let fl = (k4 * adapting_luminance)
-            + (0.1 * k4_f * k4_f * (5.0 * adapting_luminance).powf(1.0 / 3.0));
+        let fl =
+            (k4 * adapting_luminance) + (0.1 * k4_f * k4_f * (5.0 * adapting_luminance).cbrt());
         // Intermediate factor, ratio of background relative luminance to white relative luminance
         let n = y_from_lstar(background_lstar) / white_point[1];
 

--- a/src/hct/viewing_conditions.rs
+++ b/src/hct/viewing_conditions.rs
@@ -38,11 +38,11 @@ pub struct ViewingConditions {
 
 impl ViewingConditions {
     pub fn standard() -> Self {
-        ViewingConditions::s_rgb()
+        Self::s_rgb()
     }
 
     pub fn s_rgb() -> Self {
-        ViewingConditions::make(None, None, None, None, None)
+        Self::make(None, None, None, None, None)
     }
 
     /// Convenience constructor for [ViewingConditions].
@@ -59,7 +59,7 @@ impl ViewingConditions {
         background_lstar: Option<f64>,
         surround: Option<f64>,
         discounting_illuminant: Option<bool>,
-    ) -> ViewingConditions {
+    ) -> Self {
         let white_point = white_point.unwrap_or(WHITE_POINT_D65);
         let adapting_luminance = adapting_luminance.unwrap_or(-1.0);
         let background_lstar = background_lstar.unwrap_or(50.0);
@@ -158,7 +158,7 @@ impl ViewingConditions {
 
         let aw = (40.0 * rgb_a[0] + 20.0 * rgb_a[1] + rgb_a[2]) / 20.0 * nbb;
 
-        ViewingConditions {
+        Self {
             white_point,
             adapting_luminance,
             background_lstar,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,27 @@
+#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
+#![allow(
+    // pedantic lints
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::many_single_char_names,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unreadable_literal,
+    clippy::used_underscore_binding,
+    clippy::similar_names,
+    // pedantic lints for later
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::missing_panics_doc,
+    clippy::implicit_hasher,  // we use ahash on Scheme
+    clippy::suboptimal_flops, // some more cases can be optimized
+    // nursery lints for later
+    clippy::large_stack_frames,
+    clippy::cognitive_complexity
+)]
+
 pub mod blend;
 pub mod color;
 pub mod contrast;

--- a/src/palettes/core.rs
+++ b/src/palettes/core.rs
@@ -39,14 +39,14 @@ impl CorePalette {
     }
 
     /// Create a [CorePalette] from a source Argb color.
-    pub fn of(argb: Argb) -> CorePalette {
+    pub fn of(argb: Argb) -> Self {
         let cam = Cam16::from(argb);
 
-        CorePalette::_of(cam.hue, cam.chroma)
+        Self::_of(cam.hue, cam.chroma)
     }
 
-    fn _of(hue: f64, chroma: f64) -> CorePalette {
-        CorePalette::new(
+    fn _of(hue: f64, chroma: f64) -> Self {
+        Self::new(
             TonalPalette::of(hue, 48.0_f64.max(chroma)),
             TonalPalette::of(hue, 16.0),
             TonalPalette::of(hue + 60.0, 24.0),
@@ -57,14 +57,14 @@ impl CorePalette {
     }
 
     /// Create a content [CorePalette] from a source Argb color.
-    pub fn content_of(argb: Argb) -> CorePalette {
+    pub fn content_of(argb: Argb) -> Self {
         let cam = Cam16::from(argb);
 
-        CorePalette::_content_of(cam.hue, cam.chroma)
+        Self::_content_of(cam.hue, cam.chroma)
     }
 
-    fn _content_of(hue: f64, chroma: f64) -> CorePalette {
-        CorePalette::new(
+    fn _content_of(hue: f64, chroma: f64) -> Self {
+        Self::new(
             TonalPalette::of(hue, chroma),
             TonalPalette::of(hue, chroma / 3.0),
             TonalPalette::of(hue + 60.0, chroma / 2.0),

--- a/src/palettes/core.rs
+++ b/src/palettes/core.rs
@@ -34,7 +34,7 @@ impl CorePalette {
             tertiary,
             neutral,
             neutral_variant,
-            error: error.unwrap_or(TonalPalette::of(25.0, 84.0)),
+            error: error.unwrap_or_else(|| TonalPalette::of(25.0, 84.0)),
         }
     }
 

--- a/src/palettes/tonal.rs
+++ b/src/palettes/tonal.rs
@@ -83,7 +83,7 @@ impl TonalPalette {
             // case where requested chroma is 16.51, and the closest chroma is 16.49.
             // Error is minimized, but when rounded and displayed, requested chroma
             // is 17, key color's chroma is 16.
-            if chroma.round() == smallest_delta_hct.get_chroma().round() {
+            if (chroma.round() - smallest_delta_hct.get_chroma().round()).abs() < f64::EPSILON {
                 return smallest_delta_hct;
             }
 

--- a/src/palettes/tonal.rs
+++ b/src/palettes/tonal.rs
@@ -25,23 +25,23 @@ impl TonalPalette {
     /// Commonly-used tone values.
     const COMMON_TONES: [i32; 13] = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100];
 
-    pub fn common_size() -> usize {
+    pub const fn common_size() -> usize {
         Self::COMMON_TONES.len()
     }
 
-    pub fn hue(&self) -> f64 {
+    pub const fn hue(&self) -> f64 {
         self._hue
     }
 
-    pub fn chroma(&self) -> f64 {
+    pub const fn chroma(&self) -> f64 {
         self._chroma
     }
 
-    pub fn key_color(&self) -> Hct {
+    pub const fn key_color(&self) -> Hct {
         self._key_color
     }
 
-    fn new(_hue: f64, _chroma: f64, _key_color: Hct) -> Self {
+    const fn new(_hue: f64, _chroma: f64, _key_color: Hct) -> Self {
         Self {
             _hue,
             _chroma,
@@ -50,7 +50,7 @@ impl TonalPalette {
     }
 
     /// Create a Tonal Palette from hue and chroma of [hct].
-    pub fn from_hct(hct: Hct) -> Self {
+    pub const fn from_hct(hct: Hct) -> Self {
         Self::new(hct.get_hue(), hct.get_chroma(), hct)
     }
 

--- a/src/palettes/tonal.rs
+++ b/src/palettes/tonal.rs
@@ -87,7 +87,7 @@ impl TonalPalette {
                 return smallest_delta_hct;
             }
 
-            let hct_add = Hct::from(hue, chroma, start_tone + delta as f64);
+            let hct_add = Hct::from(hue, chroma, start_tone + f64::from(delta));
             let hct_add_delta = (hct_add.get_chroma() - chroma).abs();
 
             if hct_add_delta < smallest_delta {
@@ -95,7 +95,7 @@ impl TonalPalette {
                 smallest_delta_hct = hct_add;
             }
 
-            let hct_subtract = Hct::from(hue, chroma, start_tone - delta as f64);
+            let hct_subtract = Hct::from(hue, chroma, start_tone - f64::from(delta));
             let hct_subtract_delta = (hct_subtract.get_chroma() - chroma).abs();
 
             if hct_subtract_delta < smallest_delta {
@@ -114,7 +114,7 @@ impl TonalPalette {
     /// If the class was instantiated from a fixed-size list of color ints, [tone]
     /// must be in [commonTones].
     pub fn tone(&self, tone: i32) -> Argb {
-        Hct::from(self.hue(), self.chroma(), tone as f64).into()
+        Hct::from(self.hue(), self.chroma(), f64::from(tone)).into()
     }
 
     pub fn get_hct(&self, tone: f64) -> Hct {

--- a/src/palettes/tonal.rs
+++ b/src/palettes/tonal.rs
@@ -56,12 +56,12 @@ impl TonalPalette {
 
     /// Create a Tonal Palette from hue and chroma, which generates a key color.
     pub fn from_hue_and_chroma(hue: f64, chroma: f64) -> Self {
-        Self::new(hue, chroma, TonalPalette::create_key_color(hue, chroma))
+        Self::new(hue, chroma, Self::create_key_color(hue, chroma))
     }
 
     /// Create colors using [hue] and [chroma].
     pub fn of(hue: f64, chroma: f64) -> Self {
-        TonalPalette::from_hue_and_chroma(hue, chroma)
+        Self::from_hue_and_chroma(hue, chroma)
     }
 
     /// Creates a key color from a [hue] and a [chroma].

--- a/src/quantize/quantizer_map.rs
+++ b/src/quantize/quantizer_map.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use indexmap::IndexMap;
 
 use crate::Argb;
@@ -14,7 +16,7 @@ impl Quantizer for QuantizerMap {
         _max_colors: i32,
         _return_input_pixel_to_cluster_pixel: Option<bool>,
     ) -> QuantizerResult {
-        let mut color_to_count: IndexMap<Argb, u32> = Default::default();
+        let mut color_to_count = IndexMap::<Argb, u32>::default();
 
         for pixel in pixels {
             let current_pixel_count = color_to_count.get_mut(pixel);
@@ -28,7 +30,7 @@ impl Quantizer for QuantizerMap {
 
         QuantizerResult {
             color_to_count,
-            input_pixel_to_cluster_pixel: Default::default(),
+            input_pixel_to_cluster_pixel: HashMap::default(),
         }
     }
 }

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -93,11 +93,10 @@ impl QuantizerWsmeans {
 
             if let Some(value) = pixel_count {
                 pixel_count = Some(value + 1);
-                pixel_to_count.insert(*input_pixel, pixel_count.unwrap());
             } else {
                 pixel_count = Some(1);
-                pixel_to_count.insert(*input_pixel, pixel_count.unwrap());
             }
+            pixel_to_count.insert(*input_pixel, pixel_count.unwrap());
 
             if pixel_count.is_some_and(|count| count == 1) {
                 point_count += 1;

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -291,9 +291,9 @@ impl QuantizerWsmeans {
                 let count = counts[i];
 
                 pixel_count_sums[cluster_index] += count;
-                component_asums[cluster_index] += point.l * count as f64;
-                component_bsums[cluster_index] += point.a * count as f64;
-                component_csums[cluster_index] += point.b * count as f64;
+                component_asums[cluster_index] += point.l * f64::from(count);
+                component_bsums[cluster_index] += point.a * f64::from(count);
+                component_csums[cluster_index] += point.b * f64::from(count);
             }
 
             for i in 0..cluster_count {
@@ -305,9 +305,9 @@ impl QuantizerWsmeans {
                     continue;
                 }
 
-                let a = component_asums[i] / count as f64;
-                let b = component_bsums[i] / count as f64;
-                let c = component_csums[i] / count as f64;
+                let a = component_asums[i] / f64::from(count);
+                let b = component_bsums[i] / f64::from(count);
+                let c = component_csums[i] / f64::from(count);
 
                 clusters[i] = Lab { l: a, a: b, b: c };
             }

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -1,11 +1,12 @@
 use indexmap::IndexMap;
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
-use crate::quantize::point_provider_lab::PointProviderLab;
-use crate::Argb;
 use crate::color::Lab;
+use crate::quantize::point_provider_lab::PointProviderLab;
 use crate::utils::random::Random;
+use crate::Argb;
 
 use super::point_provider::PointProvider;
 use super::quantizer::QuantizerResult;
@@ -82,7 +83,7 @@ impl QuantizerWsmeans {
             _return_input_pixel_to_cluster_pixel: bool = false;
         };
 
-        let mut pixel_to_count: IndexMap<Argb, u32> = Default::default();
+        let mut pixel_to_count = IndexMap::<Argb, u32>::default();
         let mut points: Vec<Lab> = vec![];
         let mut pixels: Vec<Argb> = vec![];
         let mut point_count = 0;
@@ -313,7 +314,7 @@ impl QuantizerWsmeans {
             }
         }
 
-        let mut argb_to_population: IndexMap<Argb, u32> = Default::default();
+        let mut argb_to_population = IndexMap::<Argb, u32>::default();
 
         for i in 0..cluster_count {
             let count = pixel_count_sums[i];
@@ -333,7 +334,7 @@ impl QuantizerWsmeans {
 
         QuantizerResult {
             color_to_count: argb_to_population,
-            input_pixel_to_cluster_pixel: Default::default(),
+            input_pixel_to_cluster_pixel: HashMap::default(),
         }
     }
 }

--- a/src/quantize/quantizer_wsmeans.rs
+++ b/src/quantize/quantizer_wsmeans.rs
@@ -60,7 +60,7 @@ impl QuantizerWsmeans {
     pub fn debug_log<T: Into<String>>(log: T) {
         let log: String = log.into();
 
-        if QuantizerWsmeans::DEBUG {
+        if Self::DEBUG {
             println!("{log}");
         }
     }
@@ -164,7 +164,7 @@ impl QuantizerWsmeans {
             }
         }
 
-        QuantizerWsmeans::debug_log(format!(
+        Self::debug_log(format!(
             "have {} starting clusters, {} points",
             clusters.len(),
             points.len()
@@ -185,7 +185,7 @@ impl QuantizerWsmeans {
         let mut pixel_count_sums = vec![0; cluster_count];
 
         for iteration in 0..max_iterations {
-            if QuantizerWsmeans::DEBUG {
+            if Self::DEBUG {
                 for item in pixel_count_sums.iter_mut().take(cluster_count) {
                     *item = 0;
                 }
@@ -205,7 +205,7 @@ impl QuantizerWsmeans {
                     }
                 }
 
-                QuantizerWsmeans::debug_log(format!(
+                Self::debug_log(format!(
                     "starting iteration {}; {empty_clusters} clusters are empty of {cluster_count}",
                     iteration + 1
                 ));
@@ -266,17 +266,12 @@ impl QuantizerWsmeans {
             }
 
             if points_moved == 0 && iteration > 0 {
-                QuantizerWsmeans::debug_log(format!(
-                    "terminated after {iteration} k-means iterations"
-                ));
+                Self::debug_log(format!("terminated after {iteration} k-means iterations"));
 
                 break;
             }
 
-            QuantizerWsmeans::debug_log(format!(
-                "iteration {} moved {points_moved}",
-                iteration + 1
-            ));
+            Self::debug_log(format!("iteration {} moved {points_moved}", iteration + 1));
 
             let mut component_asums = vec![0.0; cluster_count];
             let mut component_bsums = vec![0.0; cluster_count];

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -89,12 +89,12 @@ impl QuantizerWu {
 
             self.weights[index] += count;
 
-            self.moments_r[index] += red as u32 * count;
-            self.moments_g[index] += green as u32 * count;
-            self.moments_b[index] += blue as u32 * count;
+            self.moments_r[index] += u32::from(red) * count;
+            self.moments_g[index] += u32::from(green) * count;
+            self.moments_b[index] += u32::from(blue) * count;
 
-            self.moments[index] += count as f64
-                * ((red as f64).powi(2) + (green as f64).powi(2) + (blue as f64).powi(2));
+            self.moments[index] += f64::from(count)
+                * (f64::from(red).powi(2) + f64::from(green).powi(2) + f64::from(blue)).powi(2);
         }
     }
 
@@ -268,7 +268,7 @@ impl QuantizerWu {
             .wrapping_add(db.wrapping_pow(2));
         let volume_ = Self::volume(cube, &self.weights);
 
-        xx - (hypotenuse / volume_) as f64
+        xx - f64::from(hypotenuse / volume_)
     }
 
     pub fn cut(&mut self, next: usize, i: usize) -> bool {
@@ -395,11 +395,13 @@ impl QuantizerWu {
                 continue;
             }
 
-            let mut temp_numerator = half_r
-                .wrapping_pow(2)
-                .wrapping_add(half_g.wrapping_pow(2))
-                .wrapping_add(half_b.wrapping_pow(2)) as f64;
-            let mut temp_denominator = half_w as f64;
+            let mut temp_numerator = f64::from(
+                half_r
+                    .wrapping_pow(2)
+                    .wrapping_add(half_g.wrapping_pow(2))
+                    .wrapping_add(half_b.wrapping_pow(2)),
+            );
+            let mut temp_denominator = f64::from(half_w);
             let mut temp = temp_numerator / temp_denominator;
 
             half_r = whole_r.wrapping_sub(half_r);
@@ -411,11 +413,13 @@ impl QuantizerWu {
                 continue;
             }
 
-            temp_numerator = half_r
-                .wrapping_pow(2)
-                .wrapping_add(half_g.wrapping_pow(2))
-                .wrapping_add(half_b.wrapping_pow(2)) as f64;
-            temp_denominator = half_w as f64;
+            temp_numerator = f64::from(
+                half_r
+                    .wrapping_pow(2)
+                    .wrapping_add(half_g.wrapping_pow(2))
+                    .wrapping_add(half_b.wrapping_pow(2)),
+            );
+            temp_denominator = f64::from(half_w);
             temp += temp_numerator / temp_denominator;
 
             if temp > max {

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -136,7 +136,7 @@ impl QuantizerWu {
                     self.moments_g[index] = self.moments_g[previous_index] + area_g[b];
                     self.moments_b[index] = self.moments_b[previous_index] + area_b[b];
 
-                    self.moments[index] = self.moments[previous_index] + area2[b]
+                    self.moments[index] = self.moments[previous_index] + area2[b];
                 }
             }
         }

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -2,6 +2,7 @@
 
 use core::fmt;
 use indexmap::IndexMap;
+use std::collections::HashMap;
 
 use crate::{Argb, Rgb};
 
@@ -55,7 +56,7 @@ impl Quantizer for QuantizerWu {
 
         QuantizerResult {
             color_to_count,
-            input_pixel_to_cluster_pixel: Default::default(),
+            input_pixel_to_cluster_pixel: HashMap::default(),
         }
     }
 }

--- a/src/quantize/quantizer_wu.rs
+++ b/src/quantize/quantizer_wu.rs
@@ -282,7 +282,7 @@ impl QuantizerWu {
 
         let max_rresult = self.maximize(
             &one,
-            Direction::Red,
+            &Direction::Red,
             one.r::<u8>(0) + 1,
             one.r::<u8>(1),
             whole_r,
@@ -292,7 +292,7 @@ impl QuantizerWu {
         );
         let max_gresult = self.maximize(
             &one,
-            Direction::Green,
+            &Direction::Green,
             one.g::<u8>(0) + 1,
             one.g::<u8>(1),
             whole_r,
@@ -302,7 +302,7 @@ impl QuantizerWu {
         );
         let max_bresult = self.maximize(
             &one,
-            Direction::Blue,
+            &Direction::Blue,
             one.b::<u8>(0) + 1,
             one.b::<u8>(1),
             whole_r,
@@ -370,7 +370,7 @@ impl QuantizerWu {
     pub fn maximize(
         &self,
         cube: &Cube,
-        direction: Direction,
+        direction: &Direction,
         first: u8,
         last: u8,
         whole_r: i32,
@@ -378,19 +378,19 @@ impl QuantizerWu {
         whole_b: i32,
         whole_w: i32,
     ) -> MaximizeResult {
-        let bottom_r = Self::bottom(cube, &direction, &self.moments_r);
-        let bottom_g = Self::bottom(cube, &direction, &self.moments_g);
-        let bottom_b = Self::bottom(cube, &direction, &self.moments_b);
-        let bottom_w = Self::bottom(cube, &direction, &self.weights);
+        let bottom_r = Self::bottom(cube, direction, &self.moments_r);
+        let bottom_g = Self::bottom(cube, direction, &self.moments_g);
+        let bottom_b = Self::bottom(cube, direction, &self.moments_b);
+        let bottom_w = Self::bottom(cube, direction, &self.weights);
 
         let mut max = 0.0;
         let mut cut = None;
 
         for i in first..last {
-            let mut half_r = bottom_r.wrapping_add(Self::top(cube, &direction, i, &self.moments_r));
-            let mut half_g = bottom_g.wrapping_add(Self::top(cube, &direction, i, &self.moments_g));
-            let mut half_b = bottom_b.wrapping_add(Self::top(cube, &direction, i, &self.moments_b));
-            let mut half_w = bottom_w.wrapping_add(Self::top(cube, &direction, i, &self.weights));
+            let mut half_r = bottom_r.wrapping_add(Self::top(cube, direction, i, &self.moments_r));
+            let mut half_g = bottom_g.wrapping_add(Self::top(cube, direction, i, &self.moments_g));
+            let mut half_b = bottom_b.wrapping_add(Self::top(cube, direction, i, &self.moments_b));
+            let mut half_w = bottom_w.wrapping_add(Self::top(cube, direction, i, &self.weights));
 
             if half_w == 0 {
                 continue;

--- a/src/scheme/mod.rs
+++ b/src/scheme/mod.rs
@@ -122,7 +122,7 @@ impl fmt::Display for Scheme {
 }
 
 impl Scheme {
-    pub fn new(
+    pub const fn new(
         primary: Argb,
         on_primary: Argb,
         primary_container: Argb,

--- a/src/scheme/variant/expressive.rs
+++ b/src/scheme/variant/expressive.rs
@@ -39,16 +39,16 @@ impl SchemeExpressive {
                 TonalPalette::of(
                     DynamicScheme::get_rotated_hue(
                         source_color_hct,
-                        Self::HUES.to_vec(),
-                        Self::SECONDARY_ROTATIONS.to_vec(),
+                        &Self::HUES,
+                        &Self::SECONDARY_ROTATIONS,
                     ),
                     24.0,
                 ),
                 TonalPalette::of(
                     DynamicScheme::get_rotated_hue(
                         source_color_hct,
-                        Self::HUES.to_vec(),
-                        Self::TERTIARY_ROTATIONS.to_vec(),
+                        &Self::HUES,
+                        &Self::TERTIARY_ROTATIONS,
                     ),
                     32.0,
                 ),

--- a/src/scheme/variant/vibrant.rs
+++ b/src/scheme/variant/vibrant.rs
@@ -34,16 +34,16 @@ impl SchemeVibrant {
                 TonalPalette::of(
                     DynamicScheme::get_rotated_hue(
                         source_color_hct,
-                        Self::HUES.to_vec(),
-                        Self::SECONDARY_ROTATIONS.to_vec(),
+                        &Self::HUES,
+                        &Self::SECONDARY_ROTATIONS,
                     ),
                     24.0,
                 ),
                 TonalPalette::of(
                     DynamicScheme::get_rotated_hue(
                         source_color_hct,
-                        Self::HUES.to_vec(),
-                        Self::TERTIARY_ROTATIONS.to_vec(),
+                        &Self::HUES,
+                        &Self::TERTIARY_ROTATIONS,
                     ),
                     32.0,
                 ),

--- a/src/score.rs
+++ b/src/score.rs
@@ -144,11 +144,11 @@ impl Score {
         let mut colors = vec![];
 
         if chosen_colors.is_empty() {
-            colors.push(fallback_color_argb)
+            colors.push(fallback_color_argb);
         }
 
         for chosen_hct in chosen_colors {
-            colors.push(Argb::from(chosen_hct))
+            colors.push(Argb::from(chosen_hct));
         }
 
         colors

--- a/src/score.rs
+++ b/src/score.rs
@@ -66,14 +66,14 @@ impl Score {
             colors_hct.push(hct);
 
             hue_population[hue as usize] += population;
-            population_sum += (*population) as f64;
+            population_sum += f64::from(*population);
         }
 
         // Hues with more usage in neighboring 30 degree slice get a larger number.
         let mut hue_excited_proportions = [0.0; 360];
 
         for (hue, population) in hue_population.into_iter().enumerate().take(360) {
-            let proportion = (population as f64) / population_sum;
+            let proportion = f64::from(population) / population_sum;
 
             for i in ((hue as i32) - 14)..((hue as i32) + 16) {
                 let neighbor_hue = sanitize_degrees_int(i);
@@ -126,7 +126,7 @@ impl Score {
 
                 if !chosen_colors.iter().any(|color| {
                     difference_degrees(entry.hct.get_hue(), color.get_hue())
-                        < difference_degree as f64
+                        < f64::from(difference_degree)
                 }) {
                     chosen_colors.push(hct);
                 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -208,7 +208,7 @@ impl TemperatureCache {
             }
 
             let possible_answer = &self.hcts_by_hue()[hue.round() as usize];
-            let relative_temp = (self._temps_by_hct[&possible_answer] - coldest_temp) / range;
+            let relative_temp = (self._temps_by_hct[possible_answer] - coldest_temp) / range;
             let error = (complement_relative_temp - relative_temp).abs();
 
             if error < smallest_error {

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,5 +1,5 @@
 use ahash::HashMap;
-use core::{cmp::Ordering, f64::consts::PI};
+use core::cmp::Ordering;
 
 use crate::{color::Lab, utils::math::sanitize_degrees_double, Argb, Hct};
 
@@ -190,7 +190,7 @@ impl TemperatureCache {
         } else {
             warmest_hue
         };
-        let direction_of_rotation = 1.0;
+        let direction_of_rotation = 1.0_f64;
         let mut smallest_error = 1000.0;
         let mut answer = self.hcts_by_hue()[self.input.get_hue().round() as usize];
 
@@ -199,8 +199,9 @@ impl TemperatureCache {
         // Find the color in the other section, closest to the inverse percentile
         // of the input color. This is the complement.
         for hue_addend in 0..=360 {
-            let hue =
-                sanitize_degrees_double(start_hue + direction_of_rotation * hue_addend as f64);
+            let hue = sanitize_degrees_double(
+                direction_of_rotation.mul_add(hue_addend as f64, start_hue),
+            );
 
             if !TemperatureCache::is_between(hue, start_hue, end_hue) {
                 continue;
@@ -352,9 +353,9 @@ impl TemperatureCache {
     ///   Assuming max of 130 chroma, 8.61.
     pub fn raw_temperature(color: Hct) -> f64 {
         let lab = Lab::from(Argb::from(color));
-        let hue = sanitize_degrees_double(lab.b.atan2(lab.a) * 180.0 / PI);
+        let hue = sanitize_degrees_double(lab.b.atan2(lab.a).to_degrees());
         let chroma = ((lab.a * lab.a) + (lab.b * lab.b)).sqrt();
 
-        -0.5 + 0.02 * chroma.powf(1.07) * (sanitize_degrees_double(hue - 50.0) * PI / 180.0).cos()
+        -0.5 + 0.02 * chroma.powf(1.07) * (sanitize_degrees_double(hue - 50.0).to_radians()).cos()
     }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -35,7 +35,7 @@ impl TemperatureCache {
             input,
             _hcts_by_temp: vec![],
             _hcts_by_hue: vec![],
-            _temps_by_hct: Default::default(),
+            _temps_by_hct: HashMap::default(),
             _input_relative_temperature: -1.0,
             _complement: None,
         }
@@ -293,7 +293,7 @@ impl TemperatureCache {
 
         all_hcts.push(self.input);
 
-        let mut temperatures_by_hct: HashMap<Hct, f64> = Default::default();
+        let mut temperatures_by_hct = HashMap::<Hct, f64>::default();
 
         for e in all_hcts {
             temperatures_by_hct.insert(e, TemperatureCache::raw_temperature(e));

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -73,7 +73,7 @@ impl TemperatureCache {
         }
 
         let mut hue_addend = 1;
-        let temp_step = absolute_total_temp_delta / divisions as f64;
+        let temp_step = absolute_total_temp_delta / f64::from(divisions);
 
         let mut total_temp_delta = 0.0;
 
@@ -125,7 +125,7 @@ impl TemperatureCache {
         let mut answers = vec![self.input];
 
         // First, generate analogues from rotating counter-clockwise.
-        let increase_hue_count = ((count as f64 - 1.0) / 2.0).floor() as isize;
+        let increase_hue_count = ((f64::from(count) - 1.0) / 2.0).floor() as isize;
 
         for i in 1..=increase_hue_count {
             let mut index = 0_isize - i;
@@ -200,7 +200,7 @@ impl TemperatureCache {
         // of the input color. This is the complement.
         for hue_addend in 0..=360 {
             let hue = sanitize_degrees_double(
-                direction_of_rotation.mul_add(hue_addend as f64, start_hue),
+                direction_of_rotation.mul_add(f64::from(hue_addend), start_hue),
             );
 
             if !TemperatureCache::is_between(hue, start_hue, end_hue) {
@@ -314,8 +314,11 @@ impl TemperatureCache {
         let mut hcts = vec![];
 
         for hue in 0..=360 {
-            let color_at_hue =
-                Hct::from(hue as f64, self.input.get_chroma(), self.input.get_tone());
+            let color_at_hue = Hct::from(
+                f64::from(hue),
+                self.input.get_chroma(),
+                self.input.get_tone(),
+            );
 
             hcts.push(color_at_hue);
         }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -357,7 +357,7 @@ impl TemperatureCache {
     pub fn raw_temperature(color: Hct) -> f64 {
         let lab = Lab::from(Argb::from(color));
         let hue = sanitize_degrees_double(lab.b.atan2(lab.a).to_degrees());
-        let chroma = ((lab.a * lab.a) + (lab.b * lab.b)).sqrt();
+        let chroma = lab.a.hypot(lab.b);
 
         -0.5 + 0.02 * chroma.powf(1.07) * (sanitize_degrees_double(hue - 50.0).to_radians()).cos()
     }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -179,7 +179,7 @@ impl TemperatureCache {
 
         let range = warmest_temp - coldest_temp;
         let start_hue_is_coldest_to_warmest =
-            TemperatureCache::is_between(self.input.get_hue(), coldest_hue, warmest_hue);
+            Self::is_between(self.input.get_hue(), coldest_hue, warmest_hue);
         let start_hue = if start_hue_is_coldest_to_warmest {
             warmest_hue
         } else {
@@ -203,7 +203,7 @@ impl TemperatureCache {
                 direction_of_rotation.mul_add(f64::from(hue_addend), start_hue),
             );
 
-            if !TemperatureCache::is_between(hue, start_hue, end_hue) {
+            if !Self::is_between(hue, start_hue, end_hue) {
                 continue;
             }
 
@@ -296,7 +296,7 @@ impl TemperatureCache {
         let mut temperatures_by_hct = HashMap::<Hct, f64>::default();
 
         for e in all_hcts {
-            temperatures_by_hct.insert(e, TemperatureCache::raw_temperature(e));
+            temperatures_by_hct.insert(e, Self::raw_temperature(e));
         }
 
         self._temps_by_hct = temperatures_by_hct;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -99,10 +99,10 @@ pub struct Theme {
 
 impl Theme {
     /// Generatse a theme from a source color
-    pub fn from_source_color(source: Argb, custom_colors: Vec<CustomColor>) -> Theme {
+    pub fn from_source_color(source: Argb, custom_colors: Vec<CustomColor>) -> Self {
         let palette = CorePalette::of(source);
 
-        Theme {
+        Self {
             source,
             schemes: Schemes {
                 light: SchemeTonalSpot::new(source.into(), false, None)

--- a/src/utils/math.rs
+++ b/src/utils/math.rs
@@ -1,5 +1,5 @@
 pub fn lerp(start: f64, stop: f64, amount: f64) -> f64 {
-    (1.0 - amount) * start + amount * stop
+    (1.0 - amount).mul_add(start, amount * stop)
 }
 
 pub fn sanitize_degrees_int(degrees: i32) -> u32 {

--- a/src/utils/math.rs
+++ b/src/utils/math.rs
@@ -2,7 +2,7 @@ pub fn lerp(start: f64, stop: f64, amount: f64) -> f64 {
     (1.0 - amount).mul_add(start, amount * stop)
 }
 
-pub fn sanitize_degrees_int(degrees: i32) -> u32 {
+pub const fn sanitize_degrees_int(degrees: i32) -> u32 {
     match degrees {
         value if value < 0 => (value + 360) as u32,
         value => value as u32 % 360,

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -1,8 +1,8 @@
 /// Partial LCG Algorithm implementation.
-pub(crate) struct Random(i64);
+pub struct Random(i64);
 
 impl Random {
-    pub(crate) fn new(seed: i64) -> Self {
+    pub fn new(seed: i64) -> Self {
         Self((seed ^ 0x5DEECE66Di64) & ((1i64 << 48) - 1))
     }
 
@@ -12,7 +12,7 @@ impl Random {
         ((self.0 as u64) >> (48 - bits)) as i32
     }
 
-    pub(crate) fn next_range(&mut self, range: i32) -> i32 {
+    pub fn next_range(&mut self, range: i32) -> i32 {
         if (range & -range) == range {
             return (i64::from(range).wrapping_mul(i64::from(self._next(31))) >> 31) as i32;
         }

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -2,7 +2,7 @@
 pub struct Random(i64);
 
 impl Random {
-    pub fn new(seed: i64) -> Self {
+    pub const fn new(seed: i64) -> Self {
         Self((seed ^ 0x5DEECE66Di64) & ((1i64 << 48) - 1))
     }
 

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -14,7 +14,7 @@ impl Random {
 
     pub(crate) fn next_range(&mut self, range: i32) -> i32 {
         if (range & -range) == range {
-            return ((range as i64).wrapping_mul(self._next(31) as i64) >> 31) as i32;
+            return (i64::from(range).wrapping_mul(i64::from(self._next(31))) >> 31) as i32;
         }
 
         let mut bits: i32;

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), reqwest::Error> {
 
     println!("{}", color);
 
-    _ = Theme::from_source_color(color, Default::default());
+    _ = Theme::from_source_color(color, Vec::new());
 
     // Do whatever you want...
 


### PR DESCRIPTION
This PR introduces new linting directives with pedantic and nursery groups.
It has been applied crate-wide, fixing a few hundred lints.

One lint rule, one commit.

Performance/accuracy:
- [suboptimal_flops](https://rust-lang.github.io/rust-clippy/master/index.html#/suboptimal_flops) (`mul_add`, `to_radians`, `to_degrees`)
- imprecise_flops (`cbrt`, `hypot`, `exp_m1`)
- float_cmp

Control flow:
- most other lints

Breaking:
- needless_pass_by_value

Some lints are skipped, as denoted in *lib.rs* with comments.

Closes #14 