### PR TITLE
Remove serde as required dependency by the std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libm = { version = "0.2.8", optional = true }
 
 [features]
 default = ["std"]
-std = ["serde/std", "indexmap/std", "ahash/std", "ahash/runtime-rng"]
+std = ["indexmap/std", "ahash/std", "ahash/runtime-rng"]
 image = ["dep:images"]
 serde = ["dep:serde"]
 libm = ["dep:libm"]


### PR DESCRIPTION
Currently `serde` is only optional when the `std` feature is disabled making it not really that optional. I think it should be separated from `std`