### PR TITLE
feat: implement serde::Deserialize for color types with feature serde

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -9,7 +9,7 @@ use alloc::{
 };
 use core::{fmt, str::FromStr};
 #[cfg(feature = "serde")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::{
     format,
@@ -37,7 +37,7 @@ pub const XYZ_TO_SRGB: [[f64; 3]; 3] = [
 pub const WHITE_POINT_D65: [f64; 3] = [95.047, 100.0, 108.883];
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rgb {
     pub red: u8,
     pub green: u8,
@@ -61,7 +61,7 @@ pub struct Rgb {
 /// let color = Argb::from_str("#aabbccdd").unwrap();
 /// ```
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Argb {
     pub alpha: u8,
     pub red: u8,
@@ -70,7 +70,7 @@ pub struct Argb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LinearRgb {
     pub red: f64,
     pub green: f64,
@@ -78,7 +78,7 @@ pub struct LinearRgb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Xyz {
     pub x: f64,
     pub y: f64,
@@ -86,7 +86,7 @@ pub struct Xyz {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lab {
     pub l: f64,
     pub a: f64,


### PR DESCRIPTION
Just implementing Deserialize with derive macros. Zero cost and non-zero profit because it allows not only to save colors as data files but also to parse data files into colors.