### PR TITLE
Derive useful traits

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -28,7 +28,7 @@ pub const XYZ_TO_SRGB: [[f64; 3]; 3] = [
 pub const WHITE_POINT_D65: [f64; 3] = [95.047, 100.0, 108.883];
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rgb {
     pub red: u8,
     pub green: u8,
@@ -53,7 +53,7 @@ pub struct Rgb {
 /// let color = Argb::from_str("#aabbccdd").unwrap();
 /// ```
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Argb {
     pub alpha: u8,
     pub red: u8,
@@ -62,7 +62,7 @@ pub struct Argb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LinearRgb {
     pub red: f64,
     pub green: f64,
@@ -70,7 +70,7 @@ pub struct LinearRgb {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Xyz {
     pub x: f64,
     pub y: f64,
@@ -78,7 +78,7 @@ pub struct Xyz {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lab {
     pub l: f64,
     pub a: f64,

--- a/src/hct/mod.rs
+++ b/src/hct/mod.rs
@@ -22,7 +22,7 @@ pub mod solver;
 pub mod viewing_conditions;
 
 #[derive(Default, Clone, Copy, Debug, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Hct {
     _hue: f64,
     _chroma: f64,

--- a/src/palette/tonal.rs
+++ b/src/palette/tonal.rs
@@ -24,7 +24,7 @@ use crate::{
 /// A convenience class for retrieving colors that are constant in hue and
 /// chroma, but vary in tone.
 #[derive(Clone, Copy, Debug, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TonalPalette {
     _hue: f64,
     _chroma: f64,

--- a/src/scheme/mod.rs
+++ b/src/scheme/mod.rs
@@ -9,7 +9,7 @@ use crate::{Map, color::Argb, dynamic_color::DynamicScheme, palette::CorePalette
 
 pub mod variant;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Scheme {
     pub primary: Argb,

--- a/src/scheme/mod.rs
+++ b/src/scheme/mod.rs
@@ -10,7 +10,7 @@ use crate::{Map, color::Argb, dynamic_color::DynamicScheme, palette::CorePalette
 pub mod variant;
 
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Scheme {
     pub primary: Argb,
     pub on_primary: Argb,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Custom color used to pair with a theme
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomColor {
     pub value: Argb,
@@ -23,7 +23,7 @@ pub struct CustomColor {
 }
 
 /// Color group
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ColorGroup {
     pub color: Argb,
@@ -33,7 +33,7 @@ pub struct ColorGroup {
 }
 
 /// Custom Color Group
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomColorGroup {
     pub color: CustomColor,
@@ -77,14 +77,14 @@ impl CustomColorGroup {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Schemes {
     pub light: Scheme,
     pub dark: Scheme,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Palettes {
     pub primary: TonalPalette,
@@ -274,7 +274,7 @@ impl ThemeBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Theme {
     pub source: Argb,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// Custom color used to pair with a theme
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomColor {
     pub value: Argb,
     pub name: String,
@@ -24,7 +24,7 @@ pub struct CustomColor {
 
 /// Color group
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ColorGroup {
     pub color: Argb,
     pub on_color: Argb,
@@ -34,7 +34,7 @@ pub struct ColorGroup {
 
 /// Custom Color Group
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomColorGroup {
     pub color: CustomColor,
     pub value: Argb,
@@ -78,14 +78,14 @@ impl CustomColorGroup {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Schemes {
     pub light: Scheme,
     pub dark: Scheme,
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Palettes {
     pub primary: TonalPalette,
     pub secondary: TonalPalette,
@@ -275,7 +275,7 @@ impl ThemeBuilder {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Theme {
     pub source: Argb,
     pub schemes: Schemes,


### PR DESCRIPTION
Implements same changes as #35 and #36 and additionally adds `Copy` and `Clone` traits where applicable.